### PR TITLE
Fix facebook like button

### DIFF
--- a/hasweb/static/css/app.css
+++ b/hasweb/static/css/app.css
@@ -343,3 +343,9 @@ footer .container {
     line-height: 40px;
   }
 }
+@media screen and (max-width: 600px) {
+  .fb_iframe_widget {
+    overflow-y: scroll;
+    width: 100%;
+  }
+}

--- a/hasweb/static/sass/app.scss
+++ b/hasweb/static/sass/app.scss
@@ -271,3 +271,12 @@ $body-line-height: 20px;
         }
     }
 }
+element {
+
+}
+@media screen and (max-width: 600px) {
+    .fb_iframe_widget {
+        overflow-y: scroll;
+        width: 100%;
+    }
+}

--- a/hasweb/templates/layout.html.jinja2
+++ b/hasweb/templates/layout.html.jinja2
@@ -57,9 +57,9 @@
     </div>
     <div class="col-md-3">
       <p id="footer-twitter">
-        <a href="https://twitter.com/hasgeek" class="twitter-follow-button">Follow @hasgeek</a>
+        <a href="https://twitter.com/hasgeek" class="twitter-follow-button" target="_blank">Follow @hasgeek</a>
       </p>
-      <div class="fb-follow" data-href="https://www.facebook.com/HasGeek" data-layout="standard" data-show-faces="true">Follow on Facebook</div>
+      <div class="fb-like" data-href="https://www.facebook.com/HasGeek" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true"></div>
     </div>
     <div class="col-md-3">
       <p>
@@ -76,7 +76,7 @@
     var js, fjs = d.getElementsByTagName(s)[0];
     if (d.getElementById(id)) return;
     js = d.createElement(s); js.id = id;
-    js.src = "//connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v2.5&appId=114496105304651";
+    js.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.0';
     fjs.parentNode.insertBefore(js, fjs);
   }(document, 'script', 'facebook-jssdk'));</script>
   <script src="https://platform.twitter.com/widgets.js" type="text/javascript"></script>


### PR DESCRIPTION
With the release of Graph API version 2.11, the Follow Button is deprecated. For Graph API versions 2.10 and under, the Follow Button will be supported until February 5, 2018.

Fixes #43 